### PR TITLE
found the bug with back-x

### DIFF
--- a/src/game_words.py
+++ b/src/game_words.py
@@ -1,9 +1,9 @@
 word_list = [
 'aɬqi', 
-'wəx̣t',   
+'wəx\u0323t',   
 'alta', 
 'kʰəpit', 
-'itsx̣ut', 
+'itsx\u0323ut',
 'shayim', 
 'kələkələ',  
 'spuʔuq',

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
 
 import random
 import os
+import sys
 from game_words import word_list
 from game_art import stages, logo
+DEBUG=1;
 
 
 def choose_word():
@@ -15,45 +17,60 @@ def guess_a_letter():
     guess = ""
 
     #os.system("clear")
-    guess = input("mayka palach t'səm-bit: ").lower()
-    print("Guess: ", guess)
+    guess = input("mayka palach t'səm-bit: ")
+    # quit if "." entered
+    if guess == ".":
+        print("aɬqi!")
+        sys.exit();
 
-    # while not isalpha or in ".", "ʔ", "ʰ", "'", "x̣"
-    alt_char_list = [".", "ʔ", "ʰ", "'", "x̣"]
-    #print(alt_char_list)
-    #if "x̣" in alt_char_list:
+    # translate some common typing conventions for IPA characters
+    # I didn't translate ? to ʔ because we might want to use it for help
+
+    trans_dict = {'7':'ʔ','3':'ə','E':'ə','X':'x\u0323', 'H':'ʰ', 'L':'ɬ'}
+    mytable = guess.maketrans(trans_dict)
+    guess = guess.translate(mytable).casefold()
+    print("t'ɬunas-t'səm-bit: ", guess)
+
+    valid_alphabet_list = [".", "'", "a", "b", "ch", "c'h", "d", "dj", "dz", "e", "ə", "f", "g", "h", "ʰ", "i", "k", "kʰ", "kʰw", "kw", "k'", "k'w", "l", "ɬ", "m", "n", "o", "p", "pʰ", "p'", "q", "qw", "qʰ", "qʰw", "q'", "q'w", "s", "sh", "t", "tʰ", "t'", "tɬ", "t'ɬ", "ts", "t's", "u", "v", "w", "x", "x\u0323", "x\u0323w", "y", "zh", "á", "ú", "í", "ʔ", "?"]
+    #if "x̣" in valid_alphabet_list:
     #    print("It's in the freaking list")
-    while not (guess.isalpha() or (guess in alt_char_list)):
-        print("wik t'səm-bit ukuk. munk-kakwa wəx̣t.\n")
-        guess = input("mayka palach t'səm-bit: ").lower()   # um....does this do anything weird?
+    while not (guess in valid_alphabet_list):
+        print("wik t'səm-bit ukuk. munk-kakwa wəx\u0323t.\n")
+        guess = input("mayka palach t'səm-bit: ")   # um....does this do anything weird?
+        guess = guess.translate(mytable).casefold()   # just needs the processing again
     
     return guess 
 
-# This does NOT work because x̣ is a string. So check for x̣ and adjust the display accordingly. 
+# now works for letters and the strings that make up cw t'səm-bit
 def letter_check(word, letter, display_list, lives):
-    result = [i for i in range(len(word)) if word.startswith(letter, i)]
-   
-    if not result:
+
+    location=word.find(letter);
+    if location == -1:
+        # not found
         print("t'sipi!\n")
         lives -= 1
     else:
-        for value in result:
-            display_list[value] = letter
+        while location != -1:
+            for i in range(len(letter)):
+                display_list[(location+i)] = letter[i]
+            location=word.find(letter, location+1);
+   
     
     return display_list, lives
 
 
 def create_display(word):
     display_list = []
-    #print('length of the original word: ', len(word))
-    if "x̣" in word:
-        number_of_spaces = len(word) - 1
-        #print('Adjusted length: ', number_of_spaces)
-    else: 
-        number_of_spaces = len(word)
+    number_of_spaces = len(word); 
  
-    for _ in range(number_of_spaces):
-        display_list.append("_")
+    for x in range(number_of_spaces):
+        # replace the extra character for back-x with a backspace so it doesn't show up
+        # but we still have room for it
+        if word[x] == "\u0323":
+            display_list.append("\b")
+        else:
+            display_list.append("_")
+    
    
     return display_list
 
@@ -65,8 +82,9 @@ lives = 6
 
 chosen_word = choose_word()
 
-print("chosen_word: ", chosen_word)
-print()
+if DEBUG:
+ print("chosen_word: ", chosen_word)
+ print()
 
 display_list = create_display(chosen_word)
 
@@ -83,7 +101,8 @@ while "_" in display_list and not lives == 0:
     #print(f"Guess: {guess}\n")
 
     while guess in used:
-        print(f"You used {guess} already. Try again.")
+        print(f"anqati nayka munk t'səm-bit {guess}. munk-t'ɬunas wəx\u0323t.");
+        print(f"(You used {guess} already. Try again.)")
         guess = guess_a_letter()
     used.append(guess)    
 
@@ -93,7 +112,14 @@ while "_" in display_list and not lives == 0:
     lives = result[1]
     print(f"{stages[lives]}\n")
 
-    print(f"{' '.join(display_list)}\n")
+    # i18n hell - replace is not utf-8 safe and join assumes only non-joining characters
+    # trans doesn't like escape strings
+    output_dl = ' '.join(display_list)
+    if output_dl.count(' \u0323'):
+        output_dl = '\u0323'.join(output_dl.split(' \u0323'))
+        
+
+    print(f"{output_dl}\n")
     print(f"Remaining Lives: {lives}\n")
   
 if not "_" in display_list:


### PR DESCRIPTION
added dictionary for common ascii/utf-8 substitutions
switched back-x in code and wordlist to x/u0323 for ease of reading now allows individual characters or multi-char chn t's/u0259m-bit as input
words with back-x no longer crash
translated a couple of texts
entering . as a guess ends the game
some of this should probably be in libraries or additional functions, sorry